### PR TITLE
Fix: Don't include null-byte from source in strip_suffix

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -289,7 +289,7 @@ impl CStr16Ext for CStr16 {
         let str = self.to_u16_slice();
         if *str.last()? == u16::from(suffix) {
             let mut buf = self
-                .as_slice_with_nul()
+                .as_slice()
                 .iter()
                 .map(|&c| u16::from(c))
                 .collect::<Vec<_>>();


### PR DESCRIPTION
In `strip_suffix`, buf included the null-byte from the source, so `*buf.last_mut()? = 0` set that instead of the last actual character.

This caused `setup_var.efi Setup(1):0x123` to fail with an error like "Unexpected value: 1)".

With this fix, the checks from `test_functions` now pass (as far as I can tell)